### PR TITLE
Include test files in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 include LICENSE
+include ci.py
+recursive-include test *


### PR DESCRIPTION
Downstream packagers often use the tests to make sure the packages are configured and built correctly.